### PR TITLE
Portage french

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,9 @@ module DMPonline4
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
+	config.i18n.available_locales = [:fr, :en]
+	config.i18n.default_locale = :fr
+	config.i18n.locale = :fr 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
 

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -6,7 +6,10 @@ module DMPonline4
     # tell the I18n library where to find your translations
     config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # set default locale
-    config.i18n.default_locale = :en
+    #config.i18n.default_locale = :en
+    config.i18n.locale = :fr 
+		config.i18n.default_locale = :fr
+    config.i18n.available_locales = [:fr, :en]
     
   end
 end

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -1,0 +1,59 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+fr:
+  devise:
+    confirmations:
+      confirmed: "Votre compte a bien été validé. Veuillez vous connecter."
+      send_instructions: "Vous recevrez dans quelques minutes un courriel contenant les directives pour valider votre compte."
+      send_paranoid_instructions: "Si votre adresse électronique existe dans notre base de données, vous recevrez dans quelques minutes un courriel contenant les directives pour valider votre compte."
+    failure:
+      already_authenticated: "Vous êtes déjà connecté."
+      inactive: "Votre compte n'a pas encore été activé."
+      invalid: "Courriel ou mot de passe invalide"
+      invalid_token: "Jeton d'authentification invalide"
+      locked: "Votre compte est verrouillé."
+      not_found_in_database: "Courriel ou mot de passe invalide"
+      timeout: "Votre session est expirée. Veuillez vous reconnecter pour continuer."
+      unauthenticated: "Vous devez vous connecter ou vous inscrire pour continuer."
+      unconfirmed: "Vous devez valider votre compte pour continuer."
+    mailer:
+      confirmation_instructions:
+        subject: "Valider votre compte DMP Builder"
+      reset_password_instructions:
+        subject: "Directives pour réinitialiser le mot de passe"
+      unlock_instructions:
+        subject: "Directives de déverrouillage"
+    omniauth_callbacks:
+      failure: "Nous n'avons pas pu vous authentifier à partir de %{kind} parce que '%{reason}'."
+      success: "Authentification réussie à partir du compte %{kind}."
+    passwords:
+      no_token: "Vous ne pouvez pas accéder à cette page sans y avoir été dirigé par un courriel de réinitialisation du mot de passe. Si vous avez été dirigé vers cette page à partir d’un courriel de réinitialisation, assurez-vous d'utiliser l'adresse URL complète fournie."
+      send_instructions: "Vous recevrez dans quelques minutes un courriel contenant les directives pour réinitialiser le mot de passe."
+      send_paranoid_instructions: "Si votre adresse électronique existe dans notre base de données, vous recevrez dans quelques minutes un lien de récupération du mot de passe par courriel."
+      updated: "Votre mot de passe a bien été modifié. Vous êtes maintenant connecté."
+      updated_not_active: "Votre mot de passe a bien été modifié."
+    registrations:
+      destroyed: "Votre compte a bien été supprimé. Nous espérons vous revoir bientôt."
+      signed_up: "Bienvenue! Vous êtes bien inscrit."
+      signed_up_but_inactive: "Vous êtes bien inscrit. Cependant, vous ne pouvez pas vous connecter, car votre compte n'est pas encore activé."
+      signed_up_but_locked: "Vous êtes bien inscrit. Cependant, vous ne pouvez pas vous connecter, car votre compte est verrouillé."
+      signed_up_but_unconfirmed: "Un message contenant un lien de confirmation a été envoyé à votre adresse électronique. Ouvrez ce lien pour activer votre compte. Si vous n’avez pas reçu le courriel de confirmation, vérifiez votre filtre antipourriel."
+      update_needs_confirmation: "Votre compte a bien été mis à jour, mais nous devons vérifier votre nouvelle adresse électronique. Vérifiez vos courriels et cliquez sur le lien de confirmation pour finaliser la validation de votre nouvelle adresse électronique."
+      updated: "Votre compte a bien été modifié."
+    sessions:
+      signed_in: "Connecté"
+      signed_out: "Déconnecté"
+    unlocks:
+      send_instructions: "Vous recevrez dans quelques minutes un courriel contenant les directives pour déverrouiller votre compte."
+      send_paranoid_instructions: "Si votre compte existe, vous recevrez dans quelques minutes un courriel contenant les directives pour le déverrouiller."
+      unlocked: "Votre compte a bien été déverrouillé. Veuillez vous connecter pour continuer."
+  errors:
+    messages:
+      already_confirmed: "a déjà été validé, essayez de vous connecter."
+      confirmation_period_expired: "à confirmer dans les %{period}. Veuillez faire une nouvelle demande."
+      expired: "a expiré, veuillez faire une nouvelle demande."
+      not_found: "n'a pas été trouvé"
+      not_locked: "n'était pas verrouillé"
+      not_saved:
+        one: "Une erreur a empêché d’enregistrer ce(tte) %{resource} :"
+        other: "%{count} erreurs ont empêché d’enregistrer ce(tte) %{resource} :"

--- a/config/locales/devise_invitable.fr.yml
+++ b/config/locales/devise_invitable.fr.yml
@@ -1,0 +1,18 @@
+fr:
+  devise:
+    invitations:
+      send_instructions: "Un courriel d'invitation a été envoyé à %{email}."
+      invitation_token_invalid: "Le jeton d'invitation fourni n'est pas valide!"
+      updated: "Votre mot de passe a été défini avec succès. Vous êtes maintenant connecté."
+      no_invitations_remaining: "Aucune invitation restante"
+      invitation_removed: "Votre invitation a été supprimée."
+      new:
+        header: "Envoyer une invitation"
+        submit_button: "Envoyer une invitation"
+      edit:
+        header: "Définir votre mot de passe"
+        submit_button: "Définir mon mot de passe"
+    mailer:
+      invitation_instructions:
+        subject: "Directives de confirmation"
+

--- a/config/locales/fr.bootstrap.yml
+++ b/config/locales/fr.bootstrap.yml
@@ -1,0 +1,17 @@
+
+fr:
+  helpers:
+    actions: "Actions"
+    links:
+      back: "Retour"
+      cancel: "Annuler"
+      confirm: "Êtes-vous sûr?"
+      destroy: "Supprimer"
+      new: "Nouveau"
+      edit: "Modifier"
+    titles:
+      edit: "Modifier"
+      save: "Enregistrer"
+      new: "Nouveau"
+      delete: "Supprimer"
+

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,623 @@
+fr:
+  date:
+    formats:
+      # Use the strftime parameters for formats.
+      # When no format has been given, it uses default.
+      # You can provide other formats here if you like!
+      default: "%d-%m-%Y"
+      short: "%d/%m/%Y"
+      long: "%d %B, %Y"
+
+    day_names: [Dimanche, Lundi, Mardi, Mercredi, Jeudi, Vendredi, Samedi]
+    abbr_day_names: [Dim, Lun, Mar, Mer, Jeu, Ven, Sam]
+
+    # Don't forget the nil at the beginning; there's no such thing as a 0th month
+    month_names: [~, Janvier, Février, Mars, Avril, Mai, Juin, Juillet, Août, Septembre, Octobre, Novembre, Décembre]
+    abbr_month_names: [~, Janv., Févr., Mars, Avr., Mai, Juin, Juill., Août, Sept., Oct., Nov., Déc.]
+    # Used in date_select and datetime_select.
+    order:
+      - day
+      - month
+      - year
+
+  time:
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      short: "%d %b %H:%M"
+      long: "%B %d, %Y %H:%M"
+    am: "a.m."
+    pm: "p.m."
+
+  tool_title: "DMP Builder – Service des bibliothèques de l’Université de l’Alberta"
+  dmponline3_text: "Version antérieure de DMP Builder" 
+  dcc_name: "Digital Curation Centre"
+  welcome_title: "Bienvenue"
+  welcome_text: "<p>L’outil DMP Builder est offert par le service des bibliothèques de l’Université de l’Alberta afin de vous aider à rédiger vos plans de gestion des données.</p>"
+  welcome_links: "<p><a href='http://guides.library.ualberta.ca/content.php?pid=524929&sid=4318282' target='_blank'>En savoir plus sur les plans de gestion des données</a><br/><a href='https://dataverse.library.ualberta.ca' target='_blank'>Vous souhaitez partager vos données de recherche?</a><br/><a href='http://library.ualberta.ca/researchdata' target='_blank'>Pour en savoir plus sur les services de données de recherche du service des bibliothèques\'</a></p>"
+  ccid_message: "Veuillez prendre note que nous travaillons actuellement à l’authentification de l’identifiant informatique (CCID). Vous devez créer un nouveau compte DMP Builder. Vous pourrez associer votre compte existant à votre CCID dès que la fonction sera disponible."
+  
+  screencast_error_text: "Votre navigateur ne permet pas la balise vidéo."
+
+  admin:
+    org_title: "Nom de l’organisme"
+    org: "Organisme"
+    orgs: "Organismes"
+    org_type: "Type d’organisme"
+    org_parent: "Organisme d’attache"
+    org_created_message: " L’organisme a été créé avec succès."
+    org_updated_message: " L’organisme a bien été mis à jour."
+    plans: "Plans"
+    title: "Titre"
+    desc: "Description"
+    guidance_group: "Groupe de directives"
+    no_guidance_group: "Aucun groupe de directives"
+    guidance: "Directives"
+    name: "Nom"
+    abbrev: "Abréviation"
+    question: "Question"
+    question_format: "Format de la question"
+    questions: "Questions"
+    template_title: "Titre du modèle"
+    section_title: "Titre de la section"
+    phase_title: "Titre de la phase"
+    version_title: "Titre de la version"
+    user_name: "Nom d’utilisateur"
+    firstname: "Prénom"
+    surname: "Nom"
+    user: "Utilisateur"
+    user_org_role: "Rôle de l’utilisateur au sein d’un organisme"
+    user_role_type: "Type de rôle de l’utilisateur"
+    user_role: "Rôle de l’utilisateur"
+    role: "Rôle"
+    user_status: "Statut de l’utilisateur"
+    user_type: "Type d’utilisateur"
+    last_logged_in: "Dernière connexion"
+    version_numb: "Numéro de la version"
+    details: "Renseignements"
+    phases: "Phases"
+    phase: "Phase"
+    version: "Version"
+    versions: "Versions"
+    sections: "Sections"
+    section: "Section"
+    multi_options: "Plusieurs choix de questions"
+    templates: "Modèles"
+    template: "Modèle"
+    themes: "Thèmes"
+    theme: "Thème"
+    sug_answer: "Suggestion de réponse"
+    sug_answers: "Suggestions de réponse"
+    old_temp_field: "Ancien champ de modèle"
+    old_theme_field: "Ancien champ de thème"
+
+
+  org_admin:
+    admin_area: "Section de l’administration"
+    template_label: "Modèles"
+    user_list_label: "Utilisateurs"
+    org_details_label:  "Renseignements sur l’organisme"
+    org_text: "Il s’agit des renseignements de base concernant votre organisme."
+    org_abbr_help_text_html: "Ce sont les éléments affichés comme étiquette sur vos directives, p. ex. « Directives sur les métadonnées de Glasgow ». Il vaut mieux utiliser une abréviation ou un nom abrégé."
+    users_list: "Liste des utilisateurs"
+    user_full_name: "Nom"
+    user_name: "Adresse électronique"
+    last_logged_in: "Dernière connexion"
+    how_many_plans: "Combien y a-t-il de plans?"
+    user_text_html: " Vous trouverez ci-dessous une liste des utilisateurs inscrits pour votre organisme. Vous pouvez trier les données par champ."
+    org_name: "Nom"
+    org_abbr: "Abréviation"
+    org_desc: "Description"
+    org_target_url: "Site Web"
+    org_type: "Type d’organisme"
+    parent_org: "Organisme principal"
+    last_updated: "Dernière mise à jour"
+    desc_help_text_html: "<div class='tooltip_box'>Veuillez décrire votre organisme en fournissant de l’information.</div>"
+    abbre_help_text: "Veuillez fournir une abréviation pour le nom de votre organisme."
+    template_desc_help_text_html: "<div class='tooltip_box'>Entrez une description qui vous permettra de faire la différence entre les modèles, par exemple si vous en avez pour différents publics.</div>"
+    target_url_help_text: "Veuillez indiquer une adresse Web valide."
+    name_help_text: "Veuillez indiquer le nom de votre organisme."
+    guidance_label: "Directives"
+    templates_label: "Modèles"
+    add_option_label: "Ajouter une option"
+    add_question_label: "Ajouter une question"
+    add_section_label: "Ajouter une section"
+    remove_option_label: "Supprimer"
+    option_order_label: "Classer"
+    option_text_label: "Texte"
+    option_default_label: "Défaut"
+    guidance:
+      guidance_list: "Liste des directives"
+      text_label: "Texte"
+      themes_label: "Thèmes"
+      question_label: "Question"
+      by_theme_or_by_question: "Ces directives devraient-elles s’appliquer :"
+      by_themes_label: "par thème"
+      by_question_label: "par question"
+      template: "Modèle"
+      templates: "Modèles"
+      guidance_group_label: "Groupe de directives"
+      created: "Créé(e)"
+      last_updated: "Dernière mise à jour"
+      actions: "Actions"
+      add_guidance: "Ajouter des directives"
+      created_message: "Les directives ont été créées avec succès."
+      updated_message: "Les directives ont bien été mises à jour."
+      help_text_html: "<div class='tooltip_box'>Veuillez insérer le texte des directives pour ce thème.</div>"
+      new_label: "Nouvelles directives"
+      view_all_guidance: "Voir toutes les directives"
+      text_help_text_html: "Insérez vos directives ici. Vous pouvez inclure des liens, au besoin."
+      apply_to_help_text_html: "Déterminez si vos directives doivent être affichées par thème (par défaut) ou si elles concernent uniquement une question précise dans l’un des modèles de bailleur de fonds."
+      by_themes_help_text_html: "Sélectionnez le ou les thèmes auxquels ces directives se rapportent."
+      by_question_help_text_html: "Sélectionnez le modèle, la phase, la version, la section et la question appropriés dans les options de la liste déroulante suivante pour déterminer la question précise pour laquelle ces directives devraient être affichées."
+      guidance_group_select_help_text_html: "Sélectionnez le groupe auquel ces directives se rapportent."
+      guidance_text_html: "<p>Vous pouvez rédiger des directives à afficher par thème (p. ex. des directives générales sur l’entreposage et la sauvegarde qui devraient être présentées à tous les échelons) ou vous pouvez rédiger des directives pour des questions précises. La rédaction de directives générales par thème vous permet d’économiser du temps et des efforts, car vos conseils seront automatiquement affichés dans tous les modèles au lieu d’avoir à rédiger des directives qui accompagneraient chaque modèle.</p>
+      <p>De manière générale, vous voudrez que vos directives soient affichées dans tous les modèles. Vous voudrez toutefois, dans certains cas, que les directives soient seulement affichées pour des bailleurs de fonds précis, par exemple, si vous avez des consignes précises pour les candidats qui présentent une demande au Biotechnology and Biological Sciences Research Council (BBSRC). Vous pouvez également le préciser, au besoin.</p>"
+      delete_message_html: "Vous êtes sur le point de supprimer '%{guidance_summary}'. Êtes-vous sûr de vouloir le supprimer?"
+    guidance_group:
+      add_guidance_group: "Ajouter un groupe de directives"
+      guidance_group_list: "Liste des groupes de directives"
+      name_label: "Nom"
+      subset: "Sous-ensemble facultatif"
+      subset_eg: "p. ex. école/département"
+      all_temp: "Tous les modèles"
+      help_text_add: "Veuillez indiquer le titre du groupe."
+      subset_option_help_text: "Si les directives s’adressent uniquement à un sous-ensemble d’utilisateurs, par exemple ceux d’un collège ou d’un institut précis, cochez cette case. Les utilisateurs pourront choisir d’afficher les directives destinées à ce sous-ensemble en répondant aux questions dans l’assistant « créer un plan »."
+      template_help_text_html: "Sélectionnez les modèles pour lesquels vous voulez que les directives soient affichées. Ce sera généralement pour tous les modèles."
+      title_help_text_html: "Donnez un nom approprié à votre groupe de directives, p. ex. directives de Glasgow. Ce nom sera utilisé pour indiquer à l’utilisateur final la provenance des directives, par exemple « Les directives sur les métadonnées de Glasgow »."
+      guidance_group_text_html: "<p>Vous devez d’abord créer un groupe de directives. Ces directives peuvent s’adresser à l’ensemble d’un établissement ou à un sous-ensemble, par exemple un collège ou une école, un institut ou un département précis. Lorsque vous créez des directives, on vous demandera de les assigner à un groupe de directives.</p>"
+      delete_message: "Vous êtes sur le point de supprimer '%{guidance_group_name}', ce qui modifiera les directives. Êtes-vous sûr de vouloir le supprimer?"
+      created_message: "Le groupe de directives a été créé avec succès."
+      updated_message: "Le groupe de directives a bien été mis à jour."
+      destroyed_message: "Le groupe de directives a bien été supprimé."
+    templates:
+      create_template: "Créer un modèle"
+      new_label: "Nouveau modèle"
+      template_details: "Renseignements sur le modèle"
+      edit_details: "Modifier les renseignements sur le modèle"
+      view_all_templates: "Voir tous les modèles"
+      funders_temp: "Modèles des bailleurs de fonds"
+      title_help_text: "Veuillez indiquer un titre pour votre modèle."
+      section_title_help_text: "Veuillez indiquer le titre de la section."
+      help_text_html: "<div class='tooltip_box'>Veuillez fournir une description du modèle pour ce thème.</div>"
+      create_own_template_text_html: "<p>Si vous souhaitez ajouter un modèle institutionnel pour un plan de gestion des données, utilisez le bouton « créer un modèle ». Vous pouvez créer plus d’un modèle, au besoin, par exemple un modèle pour les chercheurs et un modèle pour les étudiants au doctorat.</p>
+              <p>Votre modèle sera présenté aux utilisateurs de votre établissement lorsqu’aucun modèle de bailleur de fonds ne s’applique. Si vous souhaitez ajouter des questions aux modèles de bailleur de fonds, utilisez les options « personnaliser le modèle » ci-dessous.</p>"
+      create_new_template_text_html: "<p>Pour créer un nouveau modèle, vous devez d’abord indiquer un titre et une description. Une fois que vous les avez enregistrés, des options vous seront présentées pour ajouter une ou plusieurs phases.</p>"
+      desc_help_text_html: "Entrez une description qui vous aide à faire la différence entre les autres modèles, par exemple si vous en avez pour différents publics."
+      own_temp: "Vos modèles"
+      add_phase_label: "Ajouter une nouvelle phase +"
+      view_phase_label: "Voir la phase"
+      edit_phase_label: "Modifier la phase"
+      back_to_edit_phase_label: "Retour au mode de modification"
+      edit_phase_details_label: "Modifier les renseignements sur la phase"
+      phase_details_label: "Renseignements sur la phase"
+      phase_order_label: "Ordre d’affichage"
+      phase_details_text_html: "<p>Vous indiquez ici le titre que les utilisateurs verront. Si vous prévoyez que votre plan de gestion des données comptera plusieurs phases, vous devez l’indiquer clairement dans le titre et la description.<p/>"
+      phase_title_help_text: "Indiquez un titre pour la phase, par exemple plan de gestion des données initial, plan de gestion des données complet… Il s’agit du titre que les utilisateurs verront dans les onglets lorsqu’ils établiront un plan. Si votre plan compte une seule phase, choisissez un nom général, par exemple plan de gestion des données de Glasgow."
+      phase_number_help_text: "Cela vous permet de mettre les phases de votre modèle en ordre."
+      phase_desc_help_text_html: "Indiquez une description de base qui sera présentée aux utilisateurs et qui sera affichée au-dessus du résumé des sections et des questions auxquelles ils devront répondre."
+      phase_delete_message: "Vous êtes sur le point de supprimer '%{phase_title}', ce qui modifiera les versions, les sections et les questions en lien avec cette phase. Êtes-vous sûr de vouloir le supprimer?"
+      phase_new_text_html: "Lorsque vous créez une nouvelle phase pour votre modèle, une version sera automatiquement créée. Une fois que vous avez rempli le formulaire ci-dessous, des options vous seront présentées pour créer des sections et des questions."
+      versions_label: "Versions"
+      version_details_label: "Renseignements sur la version"
+      add_section: "Ajouter une section"
+      new_section: "Titre de la nouvelle section"
+      section_title_placeholder: "Titre de la nouvelle section"
+      section_desc_help_text_html: "<div class='tooltip_box'>Indiquez une description de base. Il pourrait s’agir d’un résumé des points traités dans la section ou des directives sur la façon de répondre. Ce texte sera affiché dans la bannière de couleur une fois que la section pourra être modifiée.</div>"
+      section_number_help_text: "Cela vous permet de mettre les sections en ordre."
+      add_question: "Ajouter une question"
+      created: "Créé(e) à"
+      last_updated: "Dernière mise à jour"
+      published_label: "Publié(e)"
+      cannot_publish: "Assurez-vous que vous avez créé au moins une phase avec une version publiée."
+      title_label: "Titre"
+      desc_label: "Description"
+      actions: "Actions"
+      customise: "Personnaliser"
+      edit_customisation: "Modifier la personnalisation"
+      created_message: "Les renseignements ont été créés avec succès."
+      updated_message: "Les renseignements ont bien été mis à jour."
+      destroyed_message: "Les renseignements ont bien été supprimés."
+      section_delete_message: "Vous êtes sur le point de supprimer '%{section_title}', ce qui modifiera les questions en lien avec cette section. Êtes-vous sûr de vouloir le supprimer?"
+    versions:
+      clone_versions_label: "Effectuer d’importantes modifications"
+      edit_versions_label: "Effectuer de petites modifications"
+      edit_label: "Modifier"
+      versions_text_html: "Une première version est automatiquement créée. Si vous désirez plus tard effectuer d’importantes modifications à des versions publiées (p. ex. ajouter une section ou des questions), vous devez créer une nouvelle version. Si vous désirez seulement corriger des erreurs typographiques ou apporter de petites modifications sans en changer le sens, modifiez la version actuelle."
+      desc_help_text_html: "Indiquez une description de base."
+      delete_message: "Vous êtes sur le point de supprimer '%{version_title}', ce qui modifiera les sections et les questions en lien avec cette version. Êtes-vous sûr de vouloir le supprimer?"
+      edit_alert_label: "Modifier l’alerte"
+      edit_alert_text: "Veuillez examiner les types de modifications que vous êtes sur le point d’effectuer, car ce plan est déjà publié et peut être en cours d’utilisation."
+    questions:
+      question_text_label: "Texte de la question"
+      question_number_label: "Numéro de la question"
+      question_edit_button: "Modifier la question"
+      answer_format_label: "Format de la réponse"
+      example_answer_label: "Exemple de réponse"
+      suggested_answer_label: "Suggestion de réponse"
+      suggested_answer_help_text_html: "Vous pouvez ajouter un exemple ou une suggestion de réponse pour aider les utilisateurs à répondre à la question. Ceux-ci seront affichés au-dessus de la case de réponse et peuvent être copiés et collés."
+      suggested_or_example_answer_label: "Suggestion de réponse / exemple"
+      suggested_or_example_answer_button: "Ajouter une suggestion de réponse ou un exemple"
+      edit_suggested_answer_button: "Modifier la suggestion de réponse ou l’exemple"
+      delete_suggested_answer_message: "Vous êtes sur le point de supprimer une suggestion de réponse ou un exemple pour '%{question_text}'. Êtes-vous sûr de vouloir le supprimer?"
+      default_value_label: "Valeur par défaut"
+      number_help_text: "Cela vous permet de mettre les questions en ordre dans une section."
+      question_format_help_text_html: "Vous pouvez choisir parmi ce qui suit :<ul><li>- zone de texte (grande case pour les paragraphes);</li> <li>- champ de texte (pour les réponses courtes);</li>
+      <li>- cases à cocher lorsque des options sont présentées dans une liste et plusieurs valeurs peuvent être sélectionnées;</li>
+      <li>- boutons d’options lorsque des options sont présentées dans une liste et qu’une seule option peut être sélectionnée;</li>
+      <li>- liste déroulante comme cette case – une seule option peut être sélectionnée;</li>
+      <li>- la case à choix multiples permet aux utilisateurs de sélectionner plusieurs options dans une liste déroulante à l’aide de la touche CTRL;</li></ul>"
+      default_answer_help_text_html: "Tout ce que vous inscrivez dans cette section apparaîtra dans la case de réponse. Si vous désirez qu’une réponse apparaisse dans un certain format (p. ex. tableaux), vous pouvez indiquer le style ici."
+      themes_label: "Thèmes"
+      question_themes_help_text_html: "<p>Sélectionnez les thèmes applicables à cette question.</p>
+      <p>Cela permet ainsi d’intégrer vos directives générales destinées à l’établissement ainsi que celles provenant d’autres sources, par exemple de DCC ou de tous les départements ou les écoles pour lesquels vous fournissez des directives. </p>
+      <p>Vous pouvez sélectionner plusieurs thèmes à l’aide de la touche CTRL.</p>"
+      default_answer_label: "Réponse par défaut"
+      guidance_label: "Directives"
+      question_guidance_help_text_html: "Indiquez des directives précises pour accompagner cette question. Si vous possédez également des directives par thème, elles seront ajoutées en fonction de vos choix ci-dessous, il vaut mieux donc ne pas reproduire en double une trop grande quantité de texte."
+      delete_message: "Vous êtes sur le point de supprimer '%{question_text}'. Êtes-vous sûr de vouloir le supprimer?"
+      question_options_help_text_html: "Indiquez toute option que vous souhaitez afficher. Si vous désirez qu’une option soit sélectionnée au préalable, cochez la case par défaut."
+
+
+
+
+  helpers:
+    home: "Accueil"
+    return_home: "Revenir à la page d’accueil"
+    admin_area: "Section du super administrateur"
+    edit_profile: "Modifier le profil"
+    view_plans_label: "Mes plans"
+    create_plan_label: "Créer un plan"
+    about_us_label: "À propos"
+    news_label: "Nouvelles"
+    help_label: "Aide"
+    contact_label: "Contact"
+    jisc: "Le DCC est financé par"
+
+    sign_in: "Se connecter"
+    sign_in_text: "Si vous avez déjà un compte."
+    sign_out: "Se déconnecter"
+    sign_up: "S’inscrire"
+    sign_up_text: "Vous êtes un nouveau utilisateur de DMP Builder? Inscrivez-vous dès maintenant."
+    signed_in: "Connecté en tant que "
+    institution_sing_in_link: ""
+    institution_sing_in: "Authentification du CCID à venir!"
+        
+
+    user_name: "Adresse électronique"
+    email: "Courriel"
+    org_not_listed: "Mon organisme n’est pas inscrit sur la liste."
+    valid_email: "Vous devez entrer une adresse électronique valide."
+    user_details_text_html: "<p>Veuillez noter que votre adresse électronique sert de nom d’utilisateur. Si vous la modifier, n’oubliez pas d’utiliser votre nouvelle adresse électronique pour vous connecter.</p>"
+    user_details_paragraph_html: "Vous pouvez modifier les renseignements ci-dessous."
+    remember_me: "Se souvenir de moi"
+    org_not_listed: "Mon organisme n’est pas inscrit sur la liste."
+
+    password: "Mot de passe"
+    current_password: "Mot de passe actuel"
+    new_password: "Nouveau mot de passe"
+    password_conf: "Confirmation du mot de passe"
+    change_password: "Modifier votre mot de passe"
+    forgot_password: "Vous avez oublié votre mot de passe?"
+    password_too_small: "Votre mot de passe doit comprendre au moins huit caractères."
+    password_no_match: "La saisie doit correspondre à ce que vous avez indiqué dans le champ précédent."
+
+    no_pass_instructions: "Vous n’avez pas reçu les directives de confirmation?"
+    no_unlock_instructions: "Vous n’avez pas reçu les directives de déverrouillage?"
+    send_password_info: "Directives pour réinitialiser le mot de passe"
+    edit_password_info: "Si vous souhaitez modifier votre mot de passe, veuillez remplir les champs suivants."
+    accept_terms_html: "J’accepte les <a href='/terms'>conditions</a> *"
+
+    text_area: "Zone de texte"
+    text_field: "Case de saisie simple"
+    radio_buttons: "Boutons d’option"
+    checkbox: "Case à cocher"
+    dropdown: "Liste déroulante"
+    multi_select_box: "Case à options multiples"
+
+    error: "Erreur!"
+    comment: "Commentaire"
+    send: "Envoyer"
+    yes: "Oui"
+    no: "Non"
+    none: "Aucun"
+    title: "Titre"
+    note: "Remarque"
+    me: "Moi"
+    view: "Voir"
+    desc: "Description"
+    save: "Enregistrer"
+    preview: "Aperçu"
+    saving: "Enregistrement..."
+    loading: "Téléchargement..."
+    unsaved: "Modifications non enregistrées"
+    unlink_account: "Dissocier le compte"
+    submit:
+      edit: "Modifier"
+      create: "Créer"
+      update: "Mettre à jour"
+      cancel: "Annuler"
+      save: "Enregistrer"
+      delete: "Supprimer"
+      back: "Retour"
+
+    name: "Nom"
+    first_name: "Prénom"
+    last_name: "Nom"
+    first_name_help_text: "Veuillez indiquer votre prénom."
+    surname_help_text: "Veuillez indiquer votre nom ou nom de famille."
+    owner: "Propriétaire"
+    orcid_id: "Numéro ORCID"
+    orcid_html: "Le numéro ORCID est un identifiant numérique constant qui différencie chaque chercheur,<a href='http://orcid.org/content/initiative' target='_blank' rel='external' class='a_orange'>pour de plus amples renseignements</a>."
+    sign_up_shibboleth_alert_text_html: "Remarque : Si vous avez déjà créé un compte dans DMPonline et que vous désirez associer le compte à votre authentifiant de l’établissement, vous devez d’abord vous <a href='/' class='a_orange'>connecter</a> à un compte DMPonline existant. Si vous n’avez jamais créé de compte DMPonline, veuillez remplir le formulaire ci-dessous."
+    shibboleth_linked_text: "Votre compte est associé à votre authentifiant de l’établissement."
+    shibboleth_to_link_text: "Associez votre compte DMPonline à votre authentifiant de l’établissement."
+    shibboleth_unlink_label: "Dissociez votre authentifiant de l’établissement."
+    shibboleth_unlink_alert: "Alerte concernant la dissociation de votre authentifiant de l’établissement"
+    shibboleth_unlink_dialog_text: "<p>Vous êtes sur le point de dissocier DMPonline de votre authentifiant de l’établissement, voulez-vous continuer?</p>"
+
+
+    section_label: "Section"
+    sections_label: "Sections"
+    questions_label: "Questions"
+    answers_label: "Réponses"
+    answer_questions: "Répondre aux questions"
+    last_edit: "Dernière modification"
+    select_action: "Sélectionnez une action"
+    answered_by: "Réponse"
+    answered_by_part2: " de "
+    suggested_answer: "Suggestion de réponse"
+    suggested_example: "Exemple de réponse"
+    notanswered: "Pas encore répondue"
+    noquestionanswered: "Aucune réponse aux questions"
+    guidance: "Directives"
+    policy_expectations: "Attentes de la politique"
+    export: "Exporter"
+
+
+    org_type:
+      funder: "Bailleur de fonds"
+      institution: "Établissement"
+      project: "Projet"
+      organisation: "Organisme"
+      org_name: "Nom de l’organisme"
+      school: "École"
+      publisher: "Éditeur"
+      other_guidance: "Autres directives"
+      template: "Modèle"
+      templates: "Modèles"
+      child: "Unité"
+      other_org_help_text: "Veuillez indiquer le nom de votre organisme."
+    
+      
+     
+
+
+    project:
+      create: "Créer un plan"
+      edit: "Modifier les renseignements sur le plan"
+      grant_title: "Numéro de la subvention"
+      grant_help_text: "Le numéro de référence de la subvention, le cas échéant [PLANS DE GESTION DES DONNÉES SUIVANT L’OCTROI SEULEMENT]"
+      not_applicable: "Sans objet / pas inscrit dans la liste"
+      multi_templates: "Il existe un certain nombre de modèles que vous pouvez utiliser. Veuillez en choisir un."
+      project_name: "Nom du plan"
+      my_project_name: "Mon plan"
+      success: "Le plan a été créé avec succès."
+      principal_investigator: "Chercheur principal/Chercheur"
+      principal_investigator_help_text: "Nom du ou des chercheurs principaux participant au projet"
+      principal_investigator_id: "Identification du chercheur principal/chercheur"
+      principal_investigator_id_help_text: "p. ex. ORCID http://orcid.org/."
+      funder_help_text: "Bailleur de fonds pour la recherche, s’il y a lieu"
+      funder_name: "Nom du bailleur de fonds"
+      project_question_desc_label: "Résumé au sujet des questions"
+      tab_plan: "Renseignements sur le plan"
+      tab_export: "Exporter"
+      export_text_html: "<p>Vous pouvez maintenant télécharger votre plan en divers formats, ce qui peut être utile si vous devez joindre votre plan à une demande de subvention.</br>
+Sélectionnez le format que vous souhaitez utiliser et cliquez sur « Exporter ».</p>"
+      project_data_contact: "Personne-ressource pour les données du plan"
+      project_data_contact_help_text: "Nom (si différent de celui susmentionné), numéro de téléphone et adresse électronique"
+      project_name_help_text: "Si vous présentez une demande de financement, inscrivez le nom de la même façon que dans la demande de subvention."
+      project_desc_help_text_html: "<div class='tooltip_box'><h4> Questions à prendre en considération :</h4><ul><li>- Quelle est la nature de votre projet de recherche?</li><li>- Quelles questions de recherche abordez-vous? </li><li>- À quelle fin les données sont-elles recueillies ou créées? </li></ul><h4>Directives :</h4><p>Résumez brièvement le type d’étude (ou les études) afin d’aider les autres à comprendre les raisons pour lesquelles les données sont recueillies ou créées.</p></div>"
+      project_identifier: "Identification"
+      project_identifier_help_text: "Une identification pertinente déterminée par le bailleur de fond ou l’établissement"
+      project_static_info: "Ce plan s’appuie sur :"
+      projects_title: "Mes plans"
+      project_settings_text: "Les points que vous sélectionnez seront affichés dans le tableau ci-dessous. Vous pouvez trier les données par en-tête ou les filtrer en indiquant une chaîne de texte dans la case de recherche."
+      project_text_when_no_project: "<p><strong>Bienvenue</strong></br> Vous êtes maintenant prêt à créer votre premier plan de gestion des données.</br>Cliquez sur le bouton « Créer un plan » ci-dessous pour commencer.</p>"
+      project_text_when_project: "<p>Le tableau ci-dessous contient une liste des plans que vous avez créés et de ceux que d’autres personnes partagent avec vous.</br>Ces plans peuvent être modifiés, partagés, exportés ou supprimés en tout temps.</p>"
+      confirmation_text: "Confirmer les renseignements sur le plan"   
+      confirmation_text_desc: "Vous utilisez le modèle générique de gestion des données de l’Université de l’Alberta. Si vous avez des suggestions sur la façon d’améliorer le modèle existant, ou si vous aimeriez ajouter d’autres modèles fondés sur les exigences d’organismes de financement ou les besoins des disciplines, communiquez avec nous à <a href='mailto:data@ualberta.ca?Subject=DMP%20Builder%20inquiry'>data@ualberta.ca</a>."
+      confirmation_button_text: "Oui, créer un plan"  
+      project_details_text_html: "Cette page vous donne un aperçu de votre plan. Elle indique les éléments sur lesquels votre plan s’appuie et donne un aperçu des questions qui vous seront posées."
+      project_details_editing_text_html: "Indiquez ci-dessous les renseignements de base sur le projet et cliquez sur « Mettre à jour » pour les enregistrer."
+      confirm_delete_text: "Êtes-vous sûr de vouloir supprimer ce plan? En supprimant le plan de votre liste, il sera également supprimé de la liste de plans des personnes avec lesquelles le plan est partagé, le cas échéant."
+      confirmation_text: "Confirmer les renseignements sur le plan"
+      confirmation_text_desc: "Vous utilisez le modèle générique de gestion des données de l’Université de l’Alberta. Si vous avez des suggestions sur la façon d’améliorer le modèle existant, ou si vous aimeriez ajouter d’autres modèles fondés sur les exigences d’organismes de financement ou les besoins des disciplines, communiquez avec nous à <a href='mailto:data@ualberta.ca?Subject=DMP%20Builder%20inquiry'>data@ualberta.ca</a>."
+      
+      confirmation_button_text: "Oui, créer un plan"
+      default_confirmation_text_desc: "Vous avez sélectionné le plan de gestion des données par défaut, qui est établi en fonction de la liste de vérification du DCC. Vous avez ainsi accès à une série générale de questions et de directives sur le plan de gestion des données. Pour de plus amples renseignements, consultez la : <a href='http://www.dcc.ac.uk/sites/default/files/documents/resource/DMP_Checklist_2013.pdf' target='_blank'>DMP checklist 2013 (Liste de vérification 2013 pour un plan de gestion des données)</a>."
+      default_confirmation_button_text: "Créer un plan"
+      alert_default_template_text_html: " Veuillez noter que %{org_name} fournit un modèle de plan de gestion des données. Si vous désirez l’utiliser, sélectionnez « Annuler », autrement cliquez sur « Créer un plan »."
+      share:
+        tab_share: "Partager"
+        shared_label: "Partagé?"
+        share_text_html: "<p>Vous pouvez permettre aux autres d’avoir accès à votre plan. Il y a trois niveaux d’autorisation.<ul><li>Les utilisateurs ayant un accès en \"lecture seule\" peuvent seulement lire le plan.</li><li>Les éditeurs peuvent collaborer au plan.</li><li>Les copropriétaires peuvent également collaborer au plan, en plus de pouvoir modifier les renseignements sur le plan et contrôler l’accès au plan.</li></ul></p><p>Ajoutez chaque collaborateur à tour de rôle en indiquant son adresse électronique ci-dessous, en choisissant un niveau d’autorisation et en cliquant sur \"Ajouter un collaborateur\".</p><p> Les personnes invitées recevront un avis par courriel pour les informer qu’elles ont accès à ce plan et pour les inviter à s’inscrire à DMP Builder si elles n’ont pas déjà un compte. Un avis est également émis lorsque le niveau d’autorisation d’un utilisateur est modifié.</p>"
+        collaborators: "Collaborateurs"
+        add_collaborator: "Ajouter un collaborateur"
+        add: "Ajouter"
+        permissions: "Autorisations"
+        permissions_desc: "Les éditeurs peuvent collaborer aux plans. Les copropriétaires ont des droits supplémentaires et peuvent modifier les renseignements sur le plan et contrôler l’accès."
+        remove: "Supprimer l’accès d’un utilisateur"
+        confirmation_question: "Êtes-vous sûr?"
+        owner: "Propriétaire"
+        co_owner: "Copropriétaire"
+        edit: "Modifier"
+        read_only: "Lecture seule"
+      export:
+        generated_by: "Ce document a été généré par DMP Builder (http://dmp.library.ualberta.ca)"
+      create_page: 
+        title: "Créer un nouveau plan"
+        desc_html: "<p>Choisissez parmi les listes déroulantes suivantes pour que nous puissions déterminer les questions et les directives à afficher dans votre plan.</p>
+        <p>Si vous ne satisfaites pas aux exigences précises d’un bailleur de fonds ou d’un établissement, <a id='create-default-plan-button' data-toggle='modal' href='#default-template-confirmation-dialog'> cliquez ici pour rédiger un plan de gestion des données générique</a> qui s’appuie sur les thèmes les plus courants.</p>"
+        default_template: "Plan de gestion des données par défaut"
+        funders_question: "Si vous présentez une demande de financement, sélectionnez votre bailleur de fonds pour la recherche."
+        funders_question_description: "Autrement, laissez l’espace vide."
+        institution_question: "Pour voir les questions ou les directives pour l’établissement, sélectionnez votre organisme."
+        institution_question_description: "Vous pouvez laisser l’espace vide ou sélectionner un autre organisme."
+        other_guidance_question: "Cochez les cases correspondantes pour sélectionner d’autres directives que vous aimeriez consulter."  
+        other_funder_name_label: "Nom du bailleur de fonds, le cas échéant"
+      configure: "Configurer"
+      columns:
+        name: "Nom"
+        owner: "Propriétaire"
+        shared: "Partagé?"
+        template_owner: "Propriétaire du modèle"
+        last_edited: "Dernière modification"
+        identifier: "Identifiant"
+        grant_number: "Numéro de la subvention"
+        principal_investigator: "Chercheur principal/chercheur"
+        data_contact: "Personne-ressource pour les données du plan"
+        description: "Description"
+      filter:
+        placeholder: "Filtrer les plans"
+        submit: "Filtrer"
+        cancel: "Annuler"
+        no_matches: "Aucune correspondance pour '%{filter}'"
+
+    plan:
+      export:
+        pdf:
+          question_not_answered: Question sans réponse
+          generated_by: Ce document a été généré par DMPonline (http://dmponline.dcc.ac.uk)
+        space_used: "Environ %{space_used}% de l’espace disponible utilisé (%{num_pages} pages maximum)"
+        project_name: "Nom du projet"
+        project_identifier: "Identifiant du projet"
+        grant_title: "Titre de la subvention"
+        principal_investigator: "Chercheur principal/chercheur"
+        project_data_contact: "Personne-ressource pour les données du plan"
+        project_description: "Description"
+        funder: "Bailleur de fonds"
+        institution: "Établissement"
+
+    settings:
+      title: "Paramètres"
+      projects:
+        title: "Paramètres - Mes plans"
+        desc: "Le tableau ci-dessous indique les colonnes disponibles qui peuvent être affichées dans la liste « Mes plans ». Choisissez celles que vous souhaitez voir apparaître."
+        errors:
+          no_name: "La colonne « nom » doit faire partie de la liste de colonnes."
+          duplicate: "Copiez le nom de la colonne. Sélectionnez chaque colonne une seule fois."
+          unknown: "Nom de colonne inconnu"
+      plans:
+        title: Titre du plan
+        reset: "Réinitialiser"
+        custom_formatting: "(À l’aide des valeurs de mise en forme de PDF personnalisées)"
+        template_formatting: "(À l’aide des valeurs de mise en forme de PDF modèles)"
+        default_formatting: "(À l’aide des valeurs de mise en forme de PDF par défaut)"
+        included_elements: "Éléments inclus"
+        pdf_formatting: "Mise en forme du PDF"
+        font_face: "Caractère"
+        font_size: "Taille"
+        margin: "Marge"
+        margins:
+          top: "Haut"
+          bottom: "Bas"
+          left: "Gauche"
+          right: "Droite"
+        max_pages: "Nombre maximal de pages"
+        errors:
+          missing_key: "Un paramètre demandé n’a pas été fourni."
+          invalid_margin: "La valeur de la marge est invalide."
+          negative_margin: "La valeur de la marge ne peut pas être négative."
+          unknown_margin: "Marge inconnue. On peut seulement choisir « haut », « bas », « gauche » ou « droite »."
+          invalid_font_size: "Taille de la police invalide"
+          invalid_font_face: "Caractère de la police invalide"
+          unknown_key: "Paramètre de mise en forme inconnu"
+          invalid_max_pages: "Nombre maximal de pages invalide"
+
+  about_page:
+    title: "À propos de DMP Builder"
+    body_text_html: "<div class='white_background'>
+    <p>
+    On demande de plus en plus aux chercheurs de rédiger des plans de gestion des données. L’Université de l’Alberta a adopté une <a href='https://policiesonline.ualberta.ca/PoliciesProcedures/Procedures/Research-Records-Stewardship-Guidance-Procedure.pdf' target='_blank'>research records stewardship policy (politique de gestion des documents de recherche)</a> qui décrit la façon de gérer et de préserver les données de recherche et les documents connexes. La présentation de plans de gestion des données (PGD) fait de plus en plus souvent partie des exigences liées à la subvention des organismes de financement. 
+    </p>
+    <p>
+    Le service des bibliothèques de l’Université de l’Alberta met cet outil pour les plans de gestion des données (DMP Builder) à la disposition des chercheurs afin de les aider dans le cadre du processus de planification de la gestion des données. Cet outil est fourni par l’entremise de DMPOnline, qui est conçu par le <a href='http://www.dcc.ac.uk/' target='_blank'>Digital Curation Centre</a> au Royaume-Uni. Toutes les données sont hébergées localement à l’Université de l’Alberta. Consultez nos <a href='/terms'>conditions d’utilisation</a> pour de plus amples renseignements. 
+    </p>
+    </div>
+    <h3>Fonctionnement de l’outil</h3>
+    <div class='white_background'>
+    <p>À l’heure actuelle, cet outil comprend un modèle générique de plan de gestion des données de l’Université de l’Alberta que les chercheurs peuvent utiliser. Des directives sont fournies afin de vous aider à interpréter les questions et à y répondre.</p>
+    <p>Nous souhaitons obtenir vos commentaires! Si vous avez des suggestions sur la façon d’améliorer le modèle existant, ou si vous aimeriez ajouter d’autres modèles fondés sur les exigences d’organismes de financement ou les besoins des disciplines, communiquez avec nous à <a href='mailto:data@ualberta.ca?Subject=DMP%20Builder%20feedback'>data@ualberta.ca</a>.
+    </p>
+    </div>
+    <h3>Démarrer</h3>
+    <div class='white_background'>
+    
+    <p>Si vous avez un compte, connectez-vous et commencez par créer ou modifier votre plan de gestion des données.</p>
+    <p> Si vous ne possédez pas de compte DMP Builder, cliquez sur <a href='/'>« S’inscrire »</a> dans la page d’accueil.</p>
+    <p>Veuillez prendre note que nous travaillons actuellement à l’authentification de l’identifiant informatique (CCID). Vous pourrez associer votre compte existant à votre CCID dès que la fonction sera disponible.</p>
+    <p>Visitez la page <a href='/help'>« Aide »</a> pour obtenir des directives.</p>
+    </div>
+    <h3>Commentaires</h3>
+    <div class='white_background'>
+    <p>Si vous avez des questions ou des commentaires au sujet de DMP Builder, communiquez avec nous par courriel à <a href='mailto:data@ualberta.ca?Subject=DMP%20Builder%20feedback'>data@ualberta.ca</a>.</p>
+    </div>"
+    
+    
+
+  help_page:
+    title: "Aide"
+    tab_1: "Concernant DMP Builder"
+    tab_2: "Concernant la planification de la gestion des données"
+    body_text_tab_2_html: "<p>Le service des bibliothèques de l’Université de l’Alberta a mis au point un<a href='http://guides.library.ualberta.ca/researchdata'>research data management guide (guide sur la gestion des données de recherche)</a> qui peut fournir d’autres directives sur la planification de la gestion des données. Si vous avez besoin de plus de directives, communiquez avec nous par courriel à <a href='mailto:data@ualberta.ca?Subject=DMP%20Builder%20help'>data@ualberta.ca</a>.</p>"
+
+
+    body_text_tab_1_html: "<p>Lorsque vous vous connectez à DMP Builder, vous serez dirigé vers la page « Mes plans ». À partir de cette page, vous pouvez modifier, partager, exporter ou supprimer l’un ou l’autre de vos plans. Vous verrez également les plans qui ont été partagés avec vous par d’autres personnes.</p>
+    <h3>Créer un plan</h3>
+    <p>Pour créer un plan, cliquez sur le bouton « Créer un plan » à la page « Mes plans » ou dans le menu du haut. Faites des choix dans les listes déroulantes et les cases à cocher afin de déterminer les questions et les directives qui seront affichées. Confirmez votre choix en cliquant sur « Oui, créer un plan ».</p>
+    <h3>Rédiger votre plan</h3>
+    <p>L’interface à onglets vous permet de naviguer dans diverses fonctions lorsque vous mettez au point votre plan.</p>
+    <ul>
+      <li>- L’option « renseignements sur le plan » comprend des renseignements administratifs de base, indique la série de questions et de directives sur laquelle votre plan s’appuie et vous donne un aperçu des questions auxquelles vous devez répondre.</li>
+      <li>- Les onglets suivants contiennent les questions auxquelles il faut répondre. Il peut y avoir plus d’un onglet si votre bailleur de fonds ou votre université pose différentes séries de questions à diverses étapes, par exemple lors d’une demande de subvention et après l’octroi d’une subvention.</li>
+      <li>- L’onglet « Partager » vous permet d’inviter d’autres personnes à lire votre plan ou à y collaborer.</li>
+      <li>- L’onglet « Exporter » vous permet de télécharger votre plan en divers formats, ce qui peut être utile si vous devez joindre votre plan à une demande de subvention.</li>
+    </ul>
+    <p>Lorsque vous consultez l’un ou l’autre des onglets de questions, vous verrez les différentes sections de votre plan affichées. Cliquez sur ces onglets à tour de rôle pour répondre aux questions. Vous pouvez choisir le format de vos réponses à l’aide des boutons de mise en forme.</p>
+    <p>Les directives sont affichées dans la partie de droite. Cliquez sur le symbole « + » pour les consulter.</p>
+    <p>N’oubliez pas d’enregistrer vos réponses avant de poursuivre.</p>
+    <h3>Partager les plans</h3>
+    <p>Inscrivez l’adresse électronique de tout collaborateur que vous aimeriez inviter à lire ou à modifier votre plan. Choisissez le niveau d’autorisation que vous souhaitez lui accorder dans les options de la liste déroulante et cliquez sur « Ajouter un collaborateur ».</p>
+    <h3>Exporter les plans</h3>
+    <p>En choisissant cette option, vous pouvez télécharger votre plan en divers formats, ce qui peut être utile si vous devez joindre votre plan à une demande de subvention. Choisissez le format dans lequel vous aimeriez voir ou télécharger votre plan et cliquez pour l’exporter. Lorsque vous vous connectez à DMP Builder, vous êtes dirigé vers la page « Mes plans ». À partir de cette page, vous pouvez modifier, partager, exporter ou supprimer l’un ou l’autre de vos plans. Vous voyez également les plans qui ont été partagés avec vous par d’autres personnes.</p>"
+
+  contact_page:
+    title: "Communiquez avec nous"
+    intro_text_html: "<p>L’outil DMP Builder est offert par le service des bibliothèques de l’Université de l’Alberta. Vous trouverez de plus amples renseignements à notre sujet sur la <a href='http://library.ualberta.ca/researchdata/' target='_blank'>Research Data Management page (page de gestion des données de recherche)</a>. Si vous souhaitez communiquer avec nous au sujet de DMP Builder, inscrivez votre demande dans le formulaire Web ci-dessous ou communiquez avec nous par courriel <a href='mailto:data@ualberta.ca?Subject=DMP%20Builder%20inquiry' target='_top'>data@ualberta.ca</a>.</p>
+     <p><a href='http://library.ualberta.ca/askus/' target='_blank'>Communiquez avec nous</a></p>"
+  
+  terms_page:
+    title: "Exploitation sous licence et conditions d’utilisation"
+    body_text_html: "
+
+    <div class='white_background'>
+    <p>L’outil DMP Builder du service des bibliothèques de l’Université de l’Alberta est fourni grâce à une application à code source libre appelée <a href='https://dmponline.dcc.ac.uk'>DMPOnline</a> qui a été mise au point par le Digital Curation Centre (DCC) et partagée en vertu de la <a href='http://www.gnu.org/licenses/agpl-3.0.html'>AGPL license (licence publique générale Affero).</a></p>
+
+    <p>Dans la mesure du possible en vertu de la loi, le service des bibliothèques de l’Université de l’Alberta a renoncé à tous les droits d’auteur et les droits connexes ou voisins sur le contenu du site Web DMP Builder et les modèles de planification de la gestion des données (mais pas sur les plans mêmes) en vertu d’une <a href='http://creativecommons.org/publicdomain/zero/1.0/'>Creative Commons Zero License (licence Creative Commons Zéro).</a></p>
+
+    <p><a href='http://creativecommons.org/publicdomain/zero/1.0/'><img src='http://i.creativecommons.org/p/zero/1.0/88x31.png' alt='CC0' /></a></p>
+    </div>
+
+    <h3>Vos renseignements personnels</h3>
+    <div class='white_background'>
+      <p>Le service des bibliothèques de l’Université de l’Alberta héberge DMP Builder et conserve vos plans de gestion des données en votre nom, mais les plans vous appartiennent et sont sous votre responsabilité. Les renseignements conservés par DMP Builder sont régis par la <a href='http://www.library.ualberta.ca/privacy/'>politique de confidentialité du Site Web</a> du service des bibliothèques de l’Université de l’Alberta.</p>
+    </div>
+
+    <h3>Mots de passe</h3>
+    <div class='white_background'>
+      <p>Votre mot de passe est mémorisé sous forme codée et ne peut pas être récupéré. Si vous avez oublié votre mot de passe, vous devez le réinitialiser.</p>
+    </div>
+    
+    <br />
+    <div class='white_background'>
+    <p>En utilisant l’outil, vous comprenez et acceptez ces conditions.</p></div>"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -307,12 +307,12 @@ fr:
     edit_password_info: "Si vous souhaitez modifier votre mot de passe, veuillez remplir les champs suivants."
     accept_terms_html: "J’accepte les <a href='/terms'>conditions</a> *"
 
-    text_area: "Zone de texte"
-    text_field: "Case de saisie simple"
-    radio_buttons: "Boutons d’option"
-    checkbox: "Case à cocher"
-    dropdown: "Liste déroulante"
-    multi_select_box: "Case à options multiples"
+    text_area: "Text area"
+    text_field: "Text field"
+    radio_buttons: "Radio buttons"
+    checkbox: "Check box"
+    dropdown: "Dropdown"
+    multi_select_box: "Multi select box"
 
     error: "Erreur!"
     comment: "Commentaire"


### PR DESCRIPTION
updated the fr.yml file and changed the following text back into English. 
It's used in admin interface to specify the input types and should stay in English. 

```
text_area: "Text area"
text_field: "Text field"
radio_buttons: "Radio buttons"
checkbox: "Check box"
dropdown: "Dropdown"
multi_select_box: "Multi select box"
```
